### PR TITLE
Memory cleanup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/cheggaaa/pb/v3 v3.1.0
 	github.com/deckarep/golang-set/v2 v2.1.0
+	github.com/gammazero/deque v0.2.1
 	golang.org/x/net v0.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpO
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
+github.com/gammazero/deque v0.2.1 h1:qSdsbG6pgp6nL7A0+K/B7s12mcCY/5l5SIUpMOl+dC0=
+github.com/gammazero/deque v0.2.1/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=

--- a/scraper.go
+++ b/scraper.go
@@ -153,7 +153,8 @@ func main() {
 
 	bar.Finish()
 
-	fmt.Println("\nFound", works_set.Cardinality(), "works across", pages, "pages and", series_set.Cardinality(), "series:\n ")
+	log.Println("Found", works_set.Cardinality(), "works across", pages, "pages and", series_set.Cardinality(), "series.")
+	fmt.Println()
 
 	// iterate over works_set
 	for url := range works_set.Iter() {

--- a/scraper.go
+++ b/scraper.go
@@ -84,7 +84,7 @@ func main() {
 	returned_works := make(chan string)   // relays detected work URLs back to coordinator
 	returned_series := make(chan string)  // ditto for series
 	finished := make(chan bool)           // tell coordinator when a crawl is finished
-	queue := deque.New[string]()          // stores URLs to be crawled
+	queue := deque.New[string](pages)     // stores URLs to be crawled
 	works_set := mapset.NewSet[string]()  // stores URLs of works that have been detected
 	series_set := mapset.NewSet[string]() // ditto for series
 

--- a/scraper.go
+++ b/scraper.go
@@ -97,8 +97,8 @@ func main() {
 	fmt.Println("Delay:  ", delay)
 
 	// populate queue
+	query := seedURL.Query()
 	for page := 1; page <= pages; page++ {
-		query := seedURL.Query()
 		query.Set("page", strconv.Itoa(page))
 		seedURL.RawQuery = query.Encode()
 


### PR DESCRIPTION
Re-architected the crawl coordination system and replaced the queue data structure to reduce memory usage. The old channel-as-queue structure could be more oversized than needed, or it could be full and block crawler goroutines from exiting while they wait to send works and series to the coordinator.