### PR TITLE
Support `retry-after` response header

### DIFF
--- a/ao3client/ao3client.go
+++ b/ao3client/ao3client.go
@@ -29,7 +29,7 @@ func NewAo3Client() (*Ao3Client, error) {
 		return nil, err
 	}
 
-	uaString := fmt.Sprintf("legowerewolf-ao3scaper/%s", (*buildInfo)["vcs.revision.withModified"])
+	uaString := fmt.Sprintf("legowerewolf-ao3scraper/%s", (*buildInfo)["vcs.revision.withModified"])
 
 	client := &http.Client{
 		Jar: jar,

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,15 @@ Tool for scraping the work URLs off of any AO3 page. Capable of navigating the
 depths of index pages. Designed for use with the
 [FanFicFare](https://github.com/JimmXinu/FanFicFare) extension for Calibre.
 
+## Notes for AO3 Maintainers
+
+- This crawler uses the user-agent string `legowerewolf-ao3scraper/\[commit\]`.
+- It rate-limits itself to 10 seconds between requests by default, although this
+  is configurable. If a user requests fewer than 10 seconds between requests, it
+  will throw a warning but proceed.
+- It will also obey `Retry-After` headers if they are set in the response.
+- I am more than happy to make changes if requested.
+
 ## Arguments
 
 - `-url` (string) URL to start crawling from

--- a/readme.md
+++ b/readme.md
@@ -12,9 +12,8 @@ depths of index pages. Designed for use with the
 ## Notes for AO3 Maintainers
 
 - This crawler uses the user-agent string `legowerewolf-ao3scraper/\[commit\]`.
-- It rate-limits itself to 10 seconds between requests by default, although this
-  is configurable. If a user requests fewer than 10 seconds between requests, it
-  will throw a warning but proceed.
+- The crawler enforces a maximum request rate of 1 request per 10 seconds,
+  although lower rates (more time between requests) are configurable.
 - It will also obey `Retry-After` headers if they are set in the response.
 - I am more than happy to make changes if requested.
 

--- a/scraper.go
+++ b/scraper.go
@@ -186,7 +186,7 @@ func main() {
 
 	// set up and start progress bar
 	bar := pb.New(pages)
-	bar.SetTemplateString(`{{counters .}} {{bar . " " ("█" | green) ("█" | green) ("█" | white) " "}} {{percent .}} {{rtime .}}`)
+	bar.SetTemplateString(`{{counters .}} {{bar . " " ("█" | green) ("█" | green) ("█" | white) " "}} {{percent .}}`)
 	if showProgress {
 		bar.Start()
 	}

--- a/scraper.go
+++ b/scraper.go
@@ -77,10 +77,8 @@ func main() {
 		}
 	}
 
-	if delay < 0 {
-		log.Fatal("Delay must be greater than or equal to 0")
-	} else if delay < 10 {
-		log.Println("Warning: Delay is less than 10 seconds. This may cause your IP to be blocked by the server.")
+	if delay < 10 {
+		log.Fatal("Delay must be greater than or equal to 10.")
 	}
 
 	// initialize client so we can check credentials if they're provided

--- a/scraper.go
+++ b/scraper.go
@@ -265,9 +265,9 @@ func crawl(crawlUrl string, returnedWorks, returnedSeries chan string, finished 
 	}
 	defer resp.Body.Close()
 	if retryHeader := resp.Header.Get("Retry-After"); retryHeader != "" {
-		if retryTime, err := strconv.Atoi(retryHeader); err != nil {
+		if retryTime, err := strconv.Atoi(retryHeader); err == nil {
 			waitTime = retryTime
-		} else if retryDate, err := http.ParseTime(retryHeader); err != nil {
+		} else if retryDate, err := http.ParseTime(retryHeader); err == nil {
 			waitTime = int(time.Until(retryDate).Seconds())
 		} else {
 			log.Printf("Server requested pause, but gave invalid time ('%s'). Aborting. Please file an issue. \n", retryHeader)


### PR DESCRIPTION
- [x] Testing
  - [x] should obey `retry-after`
  - [x] current behavior of retry/no-retry states should remain unchanged